### PR TITLE
Workaround for server returning malformed JSON

### DIFF
--- a/DripDotNet/Client/DripClient.Events.cs
+++ b/DripDotNet/Client/DripClient.Events.cs
@@ -67,7 +67,7 @@ namespace Drip
         /// <returns>On success, a DripResponse with StatusCode of Created.</returns>
         public DripResponse TrackEvents(IEnumerable<DripEvent> dripEvents)
         {
-            return PostBatchResource<DripResponse, DripEvent[]>(TrackEventsResource, EventsRequestBodyKey, dripEvents.ToArray());
+            return PostBatchResource<DripEvent[]>(TrackEventsResource, EventsRequestBodyKey, dripEvents.ToArray());
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace Drip
         /// <returns>A Task that, when completed successfully, will contain a StatusCode of Created.</returns>
         public Task<DripResponse> TrackEventsAsync(IEnumerable<DripEvent> dripEvents, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return PostBatchResourceAsync<DripResponse, DripEvent[]>(TrackEventsResource, EventsRequestBodyKey, dripEvents.ToArray(), cancellationToken);
+            return PostBatchResourceAsync<DripEvent[]>(TrackEventsResource, EventsRequestBodyKey, dripEvents.ToArray(), cancellationToken);
         }
     }
 }

--- a/DripDotNet/Client/DripClient.Subscribers.cs
+++ b/DripDotNet/Client/DripClient.Subscribers.cs
@@ -93,7 +93,7 @@ namespace Drip
         /// <returns>A DripResponse.</returns>
         public DripResponse CreateOrUpdateSubscribers(IEnumerable<ModifyDripSubscriberRequest> subscribers)
         {
-            return PostBatchResource<DripResponse, ModifyDripSubscriberRequest[]>(CreateOrUpdateSubscribersBatchResource, SubscribersRequestBodyKey, subscribers.ToArray());
+            return PostBatchResource<ModifyDripSubscriberRequest[]>(CreateOrUpdateSubscribersBatchResource, SubscribersRequestBodyKey, subscribers.ToArray());
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace Drip
         /// <returns>A Task that, when completed, will contain a DripResponse.</returns>
         public Task<DripResponse> CreateOrUpdateSubscribersAsync(IEnumerable<ModifyDripSubscriberRequest> subscribers, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return PostBatchResourceAsync<DripResponse, ModifyDripSubscriberRequest[]>(CreateOrUpdateSubscribersBatchResource, SubscribersRequestBodyKey, subscribers.ToArray(), cancellationToken);
+            return PostBatchResourceAsync<ModifyDripSubscriberRequest[]>(CreateOrUpdateSubscribersBatchResource, SubscribersRequestBodyKey, subscribers.ToArray(), cancellationToken);
         }
     }
 }

--- a/DripDotNet/Client/DripClient.Tags.cs
+++ b/DripDotNet/Client/DripClient.Tags.cs
@@ -45,7 +45,10 @@ namespace Drip
         /// <returns>On success, a DripResponse with StatusCode of Created.</returns>
         public DripResponse ApplyTagToSubscriber(string email, string tag)
         {
-            return PostResource<DripResponse>(ApplyTagToSubscriberResource, TagsRequestBodyKey, new DripTag[] { new DripTag { Email = email, Tag = tag } });
+            //This doesn't use a PostResource overload because specifying a return type causes an error
+            var req = CreatePostRequest(ApplyTagToSubscriberResource, TagsRequestBodyKey, new DripTag[] { new DripTag { Email = email, Tag = tag } });
+            var resp = Client.Execute(req);
+            return DripResponse.FromRequestResponse(req, resp);
         }
 
         /// <summary>
@@ -56,9 +59,12 @@ namespace Drip
         /// <param name="tag">The tag to apply. E.g. "Customer"</param>
         /// <param name="cancellationToken">The CancellationToken to be used to cancel the request.</param>
         /// <returns>A Task that, when completed successfully, will contain a StatusCode of NoContent.</returns>
-        public Task<DripResponse> ApplyTagToSubscriberAsync(string email, string tag, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<DripResponse> ApplyTagToSubscriberAsync(string email, string tag, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return PostResourceAsync<DripResponse>(ApplyTagToSubscriberResource, TagsRequestBodyKey, new DripTag[] { new DripTag { Email = email, Tag = tag } }, cancellationToken);
+            //This doesn't use a PostResource overload because specifying a return type causes an error
+            var req = CreatePostRequest(ApplyTagToSubscriberResource, TagsRequestBodyKey, new DripTag[] { new DripTag { Email = email, Tag = tag } });
+            var resp = await Client.ExecuteTaskAsync(req, cancellationToken);
+            return DripResponse.FromRequestResponse(req, resp);
         }
 
         /// <summary>

--- a/DripDotNet/Protocol/DripResponse.cs
+++ b/DripDotNet/Protocol/DripResponse.cs
@@ -89,14 +89,27 @@ namespace Drip
             return (int)StatusCode < 400 && !HasErrors();
         }
 
-        internal protected virtual void ProcessRestResponse(IRestRequest restRequest, IRestResponse restResponse)
+        internal protected static DripResponse FromRequestResponse(IRestRequest restRequest, IRestResponse restResponse)
         {
-            OriginalRequest = restRequest;
-            OriginalResponse = restResponse;
+            var result = new DripResponse();
 
-            if (restResponse == null) return;
+            result.OriginalRequest = restRequest;
+            result.OriginalResponse = restResponse;
+            result.StatusCode = restResponse.StatusCode;
 
-            StatusCode = restResponse.StatusCode;
+            return result;
+        }
+
+        internal protected static TResponse FromRequestResponse<TResponse>(IRestRequest restRequest, IRestResponse<TResponse> restResponse)
+            where TResponse : DripResponse, new()
+        {
+            var result = restResponse.Data ?? new TResponse();
+
+            result.OriginalRequest = restRequest;
+            result.OriginalResponse = restResponse;
+            result.StatusCode = restResponse.StatusCode;
+
+            return result;
         }
     }
 }

--- a/DripDotNetTests/SerializerTests.cs
+++ b/DripDotNetTests/SerializerTests.cs
@@ -25,6 +25,7 @@ using Drip;
 using Drip.Protocol;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Xunit;
 
 namespace DripDotNetTests
@@ -65,7 +66,7 @@ namespace DripDotNetTests
             };
 
             var actualString = serializer.Serialize(sourceObj);
-            var expectedString = string.Format("{{\"test\":\"abc\",\"testing_part_deux\":2,\"nested_list\":[],\"its_now\":\"{0:o}\"}}", sourceObj.ItsNow);
+            var expectedString = string.Format("{{\"test\":\"abc\",\"testing_part_deux\":2,\"nested_list\":[],\"its_now\":\"{0}\"}}", sourceObj.ItsNow.Value.ToString(@"yyyy-MM-dd\THH:mm:ss.FFFFFFF\Z", CultureInfo.InvariantCulture));
 
             Assert.Equal(expectedString, actualString);
         }

--- a/DripDotNetTests/TagTests.cs
+++ b/DripDotNetTests/TagTests.cs
@@ -92,9 +92,6 @@ namespace DripDotNetTests
             DripAssert.Success(result, HttpStatusCode.NoContent);
         }
 
-
-
-
         [Fact]
         public async Task CanApplyAndRemoveTagsAsync()
         {

--- a/README.md
+++ b/README.md
@@ -117,11 +117,3 @@ within the Visual Studio solution.
 
 Since we do not yet support creating campaigns via API there is a TestCampaignId
 constant in the CampaignTests.
-
-## Known Issues
-
-	1. Async operations that return empty results do not report the correct StatusCode on the DripResponse. This causes the associated integration tests to fail.
-		a. ApplyTagToSubscriberAsync
-		b. RemoveTagFromSubscriberAsync
-		c. CreateOrUpdateSubscribersAsync
-		d. TrackEventsAsync


### PR DESCRIPTION
- Refactored to use Async methods that don't try to deserialize a body when appropriate, so it ignores the non-empty body
- Cleaned up a sporadically broken serialization test due to DateTime format differences