### PR TITLE
Add user_id to CreateOrUpdateSubscriber

### DIFF
--- a/DripDotNet/Resources/DripSubscriber.cs
+++ b/DripDotNet/Resources/DripSubscriber.cs
@@ -40,6 +40,11 @@ namespace Drip
         public string Email { get; set; }
 
         /// <summary>
+        /// The subscriber's user id (a unique identifier for the user, such as a primary key).
+        /// </summary>
+        public string UserId { get; set; }
+
+        /// <summary>
         /// The subscriber's time zone (in Olsen format). Defaults to Etc/UTC
         /// </summary>
         public string Timezone { get; set; }
@@ -107,6 +112,11 @@ namespace Drip
         /// The subscriber's email address.
         /// </summary>
         public string Email { get; set; }
+
+        /// <summary>
+        /// The subscriber's user id (a unique identifier for the user, such as a primary key).
+        /// </summary>
+        public string UserId { get; set; }
 
         /// <summary>
         /// The subscriber's time zone (in Olsen format). Defaults to Etc/UTC

--- a/DripDotNetTests/CampaignTests.cs
+++ b/DripDotNetTests/CampaignTests.cs
@@ -35,7 +35,7 @@ namespace DripDotNetTests
     public class CampaignTests: IClassFixture<DripClientFixture>, IClassFixture<SubscriberFactoryFixture>
     {
         //TODO: put this in a configuration file
-        const string TestCampaignId = "85478432";   // "3057996"; //This is a test campaign in my test account
+        const string TestCampaignId = "3057996"; //This is a test campaign in my test account. Replace this with a Campaign Id from your account before running tests.
 
         DripClientFixture dripClientFixture;
         SubscriberFactoryFixture subscriberFactoryFixture;

--- a/DripDotNetTests/CampaignTests.cs
+++ b/DripDotNetTests/CampaignTests.cs
@@ -35,7 +35,7 @@ namespace DripDotNetTests
     public class CampaignTests: IClassFixture<DripClientFixture>, IClassFixture<SubscriberFactoryFixture>
     {
         //TODO: put this in a configuration file
-        const string TestCampaignId = "3057996"; //This is a test campaign in my test account
+        const string TestCampaignId = "85478432";   // "3057996"; //This is a test campaign in my test account
 
         DripClientFixture dripClientFixture;
         SubscriberFactoryFixture subscriberFactoryFixture;

--- a/DripDotNetTests/SubscriberFactoryFixture.cs
+++ b/DripDotNetTests/SubscriberFactoryFixture.cs
@@ -44,6 +44,7 @@ namespace DripDotNetTests
             var result = new ModifyDripSubscriberRequest
             {
                 Email = GetRandomEmailAddress(),
+                UserId = IntUtil.Random(1001,9999).ToString(),
                 CustomFields = new Dictionary<string, string>
                 { 
                     {"id", Guid.NewGuid().ToString("n")},
@@ -68,6 +69,22 @@ namespace DripDotNetTests
 
         public void Dispose()
         {
+        }
+    }
+
+    public static class IntUtil
+    {
+        private static Random random;
+
+        private static void Init()
+        {
+            if (random == null) random = new Random();
+        }
+
+        public static int Random(int min, int max)
+        {
+            Init();
+            return random.Next(min, max);
         }
     }
 }

--- a/DripDotNetTests/SubscriberFactoryFixture.cs
+++ b/DripDotNetTests/SubscriberFactoryFixture.cs
@@ -72,6 +72,9 @@ namespace DripDotNetTests
         }
     }
 
+    /*
+    This support class is used to generate a random integer for the UserId field.
+    */
     public static class IntUtil
     {
         private static Random random;

--- a/DripDotNetTests/SubscriberTests.cs
+++ b/DripDotNetTests/SubscriberTests.cs
@@ -56,6 +56,7 @@ namespace DripDotNetTests
             Assert.Equal(1, result.Subscribers.Count);
 
             var actual = result.Subscribers.First();
+            Assert.Equal(expected.UserId, actual.UserId);
             DripAssert.Equal(expected.CustomFields, actual.CustomFields);
             DripAssert.ContainsSameItems(expected.Tags, actual.Tags);
 
@@ -90,6 +91,7 @@ namespace DripDotNetTests
 
             var actual = result.Subscribers.First();
             Assert.Equal(expected.Email, actual.Email);
+            Assert.Equal(expected.UserId, actual.UserId);
             DripAssert.Equal(expected.CustomFields, actual.CustomFields);
             DripAssert.ContainsSameItems(expected.Tags, actual.Tags);
 


### PR DESCRIPTION
Add support for specifying the user_id field when creating or updating a subscriber.

I also updated the unit tests to support and test this field.

Note that this change was only made to the VS 2015 solution. I don't have access to VS 2013 to make the change in the VS 2013 solution, and my recommendation is that you remove that solution from the .NET SDK as it is now two versions old with the recent introduction of VS 2017.