### PR TITLE
Add more info to `.csproj` file to improve NuGet packaging

### DIFF
--- a/DripDotNet/DripDotNet.csproj
+++ b/DripDotNet/DripDotNet.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageId>DripDotNetSDK</PackageId>
     <AssemblyVersion>3.1.0</AssemblyVersion>
+    <Version>3.1.0</Version>
+    <Authors>Drip</Authors>
+    <Company>Drip</Company>
+    <PackageTags>email;marketing;drip;ecommerce;newsletters</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some of this stuff is stuff I used to package and upload the first version of the package here: https://www.nuget.org/packages/DripDotNetSDK/

I then noticed that one of the two other versions of this package (https://www.nuget.org/packages/Leadpages.Drip.DripDotNet) has tags to improve discoverability, so I added those in addition to the things I used to upload the package to NuGet.